### PR TITLE
Create builder image to reduce CI run time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: trusty
 services:
 - docker
 
+before_install:
+  docker pull alukiano/builder:28
+
 install:
 - git reset --hard
 

--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -1,53 +1,6 @@
-FROM fedora@sha256:57d86e03971841e79585379f8346289ceb5a3e8ee06933fbd5064b4f004659d1
-
-RUN dnf -y install make \
-    git \
-    mercurial \
-    sudo \
-    gcc \
-    findutils \
-    gradle \
-    rsync-daemon \
-    rsync \
-    protobuf-compiler && dnf -y clean all
-
-# Add bazel repo
-COPY bazel.repo /etc/yum.repos.d/
-
-# Install bazel and all needed dependencies
-RUN dnf -y install gcc-c++ glibc-devel bazel docker \
-    && dnf -y clean all
-
-ENV GIMME_GO_VERSION=1.10
-
-RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
-
-ENV GOPATH="/go" GOBIN="/usr/bin"
+FROM alukiano/builder@sha256:5068f41cafc51af22ee2a2f2a1426b6461e925777d19e919068c68faabf3d4c5
 
 ADD rsyncd.conf /etc/rsyncd.conf
-
-RUN \
-    mkdir -p /go && \
-    source /etc/profile.d/gimme.sh && \
-    go get github.com/mattn/goveralls && \
-    go get -u github.com/golang/dep/cmd/dep && \
-    go get golang.org/x/tools/cmd/goimports && \
-    git clone https://github.com/mvdan/sh.git $GOPATH/src/mvdan.cc/sh && \
-    cd $GOPATH/src/mvdan.cc/sh/cmd/shfmt && \
-    git checkout v2.5.0 && \
-    go get mvdan.cc/sh/cmd/shfmt && \
-    go install && \
-    go get -u github.com/golang/mock/gomock && \
-    go get -u github.com/golang/mock/mockgen && \
-    go get -u github.com/onsi/ginkgo/ginkgo && \
-    git clone https://github.com/kubernetes/code-generator -b release-1.11 $GOPATH/src/k8s.io/code-generator && \
-    cd $GOPATH/src/k8s.io/code-generator && \
-    go install ./cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen} && \
-    go get -u -d github.com/golang/protobuf/protoc-gen-go && \
-    cd $GOPATH/src/github.com/golang/protobuf/protoc-gen-go && \
-    git checkout 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9 && \
-    go install
-
 ADD entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/hack/docker-builder/bazel.repo
+++ b/hack/docker-builder/bazel.repo
@@ -1,8 +1,0 @@
-[vbatts-bazel]
-name=Copr repo for bazel owned by vbatts
-baseurl=https://copr-be.cloud.fedoraproject.org/results/vbatts/bazel/fedora-$releasever-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=0
-enabled=1
-enabled_metadata=1

--- a/hack/docker-builder/build.sh
+++ b/hack/docker-builder/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker build . -t docker.io/alukiano/noderecovery-docker-builder

--- a/hack/docker-builder/publish.sh
+++ b/hack/docker-builder/publish.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker push docker.io/alukiano/noderecovery-docker-builder:latest

--- a/images/base/builder/Dockerfile
+++ b/images/base/builder/Dockerfile
@@ -1,0 +1,48 @@
+FROM fedora@sha256:57d86e03971841e79585379f8346289ceb5a3e8ee06933fbd5064b4f004659d1
+
+RUN dnf -y install make \
+    git \
+    docker \
+    mercurial \
+    sudo \
+    gcc \
+    gcc-c++ \
+    glibc-devel \
+    findutils \
+    gradle \
+    rsync-daemon \
+    rsync \
+    protobuf-compiler \
+    dnf-plugins-core
+
+RUN dnf copr -y enable vbatts/bazel \
+    && dnf install -y bazel \
+    && dnf -y clean all
+
+ENV GIMME_GO_VERSION=1.10
+
+RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
+
+ENV GOPATH="/go" GOBIN="/usr/bin"
+
+RUN \
+    mkdir -p /go && \
+    source /etc/profile.d/gimme.sh && \
+    go get github.com/mattn/goveralls && \
+    go get -u github.com/golang/dep/cmd/dep && \
+    go get golang.org/x/tools/cmd/goimports && \
+    git clone https://github.com/mvdan/sh.git $GOPATH/src/mvdan.cc/sh && \
+    cd $GOPATH/src/mvdan.cc/sh/cmd/shfmt && \
+    git checkout v2.5.0 && \
+    go get mvdan.cc/sh/cmd/shfmt && \
+    go install && \
+    go get -u github.com/golang/mock/gomock && \
+    go get -u github.com/golang/mock/mockgen && \
+    go get -u github.com/onsi/ginkgo/ginkgo && \
+    git clone https://github.com/kubernetes/code-generator -b release-1.11 $GOPATH/src/k8s.io/code-generator && \
+    cd $GOPATH/src/k8s.io/code-generator && \
+    go install ./cmd/{defaulter-gen,client-gen,lister-gen,informer-gen,deepcopy-gen} && \
+    go get -u -d github.com/golang/protobuf/protoc-gen-go && \
+    cd $GOPATH/src/github.com/golang/protobuf/protoc-gen-go && \
+    git checkout 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9 && \
+    go install

--- a/images/base/publish-all.sh
+++ b/images/base/publish-all.sh
@@ -2,8 +2,6 @@
 
 set -ex
 
-echo $1
-
 for dockerfile in "$@"; do
     image_name="$(dirname ${dockerfile} | xargs basename)"
     docker push docker.io/alukiano/${image_name}:28

--- a/tests/node_remediation_test.go
+++ b/tests/node_remediation_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"fmt"
 	"flag"
 	"time"
 
@@ -121,8 +120,7 @@ var _ = Describe("Node Remediation", func() {
 
 			By("Checking that the node remediation object changed phase to \"Remediate\"")
 			waitForNodeRemediatioPhase(v1.NodeRemediationPhaseRemediate, 70*time.Second)
-			
-			fmt.Println(time.Now())
+
 			By("Checking that the machine object was recreated after node remediation start")
 			Eventually(func() bool {
 				machine, err := clusterClient.ClusterV1alpha1().Machines(tests.NamespaceClusterApiExternalProvider).Get(tests.MachineName, metav1.GetOptions{})
@@ -131,7 +129,6 @@ var _ = Describe("Node Remediation", func() {
 				}
 				return machine.CreationTimestamp.After(remediationStart)
 			}, 180*time.Second, time.Second).Should(BeTrue())
-			fmt.Println(time.Now())
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
On each CI run, it creates a build image from scratch, that can take a lot of time.
To reduce runtime I created the base image that includes all needed packages and pushed it to docker hub, in the future we also can cache this image under CI environment.